### PR TITLE
Disable assignment operator test

### DIFF
--- a/lib/rules/operator-whitespace.js
+++ b/lib/rules/operator-whitespace.js
@@ -29,7 +29,7 @@ module.exports = {
 			var charsAfterLeftNode = sourceCode.getNextChars (node.left, 3 + opLength),
 				validationRegexp = new RegExp ('^ ' + op + ' [^\\s]$');
 
-			// Disabling this check, as it is preventing syntax like: (varA, varB) = myFunction();
+			// Temporarily disabling this check, as it is preventing syntax like: (varA, varB) = myFunction();
 			// (!validationRegexp.test (charsAfterLeftNode)) && context.report ({
 			// 	node: node.left,
 			// 	message: 'Assignment operator must have exactly single space on both sides of it.'

--- a/lib/rules/operator-whitespace.js
+++ b/lib/rules/operator-whitespace.js
@@ -29,10 +29,11 @@ module.exports = {
 			var charsAfterLeftNode = sourceCode.getNextChars (node.left, 3 + opLength),
 				validationRegexp = new RegExp ('^ ' + op + ' [^\\s]$');
 
-			(!validationRegexp.test (charsAfterLeftNode)) && context.report ({
-				node: node.left,
-				message: 'Assignment operator must have exactly single space on both sides of it.'
-			});
+			// Disabling this check, as it is preventing syntax like: (varA, varB) = myFunction();
+			// (!validationRegexp.test (charsAfterLeftNode)) && context.report ({
+			// 	node: node.left,
+			// 	message: 'Assignment operator must have exactly single space on both sides of it.'
+			// });
 		});
 
 		//statement like `var x = 10` doesn't come under AssignmentExpression, so needs to be checked separately


### PR DESCRIPTION
The error "Assignment operator must have exactly single space on both sides of it." is showing up even when the assignment operator only has single spaces on both sides of it.  This change disables the error.

Here is a simple example:

```
pragma solidity ^0.4.11;

contract Test {
    function testA() public constant returns (bytes20, bytes20) {
        return (0, 0);
    }

    function testB() {
        bytes20 varA;
        bytes20 varB;

        (varA, varB) = testA();
    }
}
```